### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/src/rcc/IC/ItemList.cls
+++ b/src/rcc/IC/ItemList.cls
@@ -1,9 +1,38 @@
 Class rcc.IC.ItemList Extends (%Persistent, %Populate) [ Final ]
 {
+
 Property Company As %String [ Required ];
+
 Property Region As list Of %String(COLLATION = "EXACT", POPSPEC = ":4", VALUELIST = ",US,CD,MX,EU,JP,AU,ZA") [ Required ];
+
 Property Items As list Of rcc.IC.serItem(POPSPEC = ":4") [ Required ];
+
 Index xreg On Region(ELEMENTS);
+
 Index xitm On Items(ELEMENTS);
+
 Index ycol On Items(ELEMENTS).Color;
+
+Storage Default
+{
+<Data name="ItemListDefaultData">
+<Value name="1">
+<Value>Company</Value>
+</Value>
+<Value name="2">
+<Value>Region</Value>
+</Value>
+<Value name="3">
+<Value>Items</Value>
+</Value>
+</Data>
+<DataLocation>^rcc.IC.ItemListD</DataLocation>
+<DefaultData>ItemListDefaultData</DefaultData>
+<IdLocation>^rcc.IC.ItemListD</IdLocation>
+<IndexLocation>^rcc.IC.ItemListI</IndexLocation>
+<StreamLocation>^rcc.IC.ItemListS</StreamLocation>
+<Type>%Storage.Persistent</Type>
 }
+
+}
+

--- a/src/rcc/IC/serItem.cls
+++ b/src/rcc/IC/serItem.cls
@@ -1,6 +1,29 @@
 Class rcc.IC.serItem Extends (%SerialObject, %Populate)
 {
+
 Property Subject As %String [ Required ];
+
 Property Change As %TimeStamp [ Required ];
+
 Property Color As %String(COLLATION = "EXACT", VALUELIST = ",red,white,blue,yellow,black,unknown") [ Required ];
+
+Storage Default
+{
+<Data name="serItemState">
+<Value name="1">
+<Value>Subject</Value>
+</Value>
+<Value name="2">
+<Value>Change</Value>
+</Value>
+<Value name="3">
+<Value>Color</Value>
+</Value>
+</Data>
+<State>serItemState</State>
+<StreamLocation>^rcc.IC.serItemS</StreamLocation>
+<Type>%Storage.Serial</Type>
 }
+
+}
+


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5

USER>install collection-index-and-query
[collection-index-and-query]    Reload START (D:\InterSystems\IRISPY\mgr\.modules\COLLECTIONINDEXANDQUERY\collection-index-and-query\1.0.1\)
[collection-index-and-query]    Reload SUCCESS
[collection-index-and-query]    Module object refreshed.
[collection-index-and-query]    Validate START
[collection-index-and-query]    Validate SUCCESS
[collection-index-and-query]    Compile START
[collection-index-and-query]    Compile FAILURE
ERROR! Storage on class rcc.IC.ItemList modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce